### PR TITLE
Ft create GitHub adaptor display GitHub users 155965831

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,9 +29,12 @@ dependencies {
     implementation 'com.android.support:cardview-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     implementation 'com.android.support:design:27.1.1'
+    implementation 'com.github.bumptech.glide:glide:4.7.1'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.7.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'com.squareup.picasso:picasso:2.4.0'
 }
 
 apply from: '../gradle/githooks.gradle'

--- a/app/src/main/java/githubuser/adapter/GitHubAdaptor.java
+++ b/app/src/main/java/githubuser/adapter/GitHubAdaptor.java
@@ -10,6 +10,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.example.jakanakiwanuka.mrmlevelup.R;
+import com.squareup.picasso.Picasso;
 
 import java.util.List;
 
@@ -37,8 +38,9 @@ public class GitHubAdaptor extends RecyclerView.Adapter<GitHubAdaptor.UserViewHo
      * View Holder to contain the data of the individual when clicked.
      */
     public static class UserViewHolder extends RecyclerView.ViewHolder {
-        private final ImageView mUserImageView; //change this later
-         TextView mUserTextView;
+        ImageView mUserImageView; //change this later
+        TextView mUserTextView;
+        TextView mUserTextView2;
 
         /**
          * Instance of view holder that is not bound to any data yet.
@@ -53,7 +55,8 @@ public class GitHubAdaptor extends RecyclerView.Adapter<GitHubAdaptor.UserViewHo
 
     @Override
     public UserViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.content_main,
+        View view = LayoutInflater.from(parent
+                .getContext()).inflate(R.layout.content_main,
                 parent, false);
         return new UserViewHolder(view);
     }
@@ -62,11 +65,16 @@ public class GitHubAdaptor extends RecyclerView.Adapter<GitHubAdaptor.UserViewHo
     public void onBindViewHolder(UserViewHolder holder, int position) {
         final GithubUsers githubUser = users.get(position);
         holder.mUserTextView.setText(githubUser.getUserName());
+        Picasso.with(context)
+                .load(githubUser.getProfileImage())
+                .placeholder(R.mipmap.ic_launcher)
+                .into(holder.mUserImageView);
 
         holder.itemView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 Intent userDetail = new Intent(v.getContext(), DetailActivity.class);
+                userDetail.putExtra("githubImage", githubUser.getProfileImage());
                 userDetail.putExtra("githubUser", githubUser.getUserName());
                 userDetail.putExtra("userOrg", githubUser.getOrganizationUrl());
                 v.getContext().startActivity(userDetail);

--- a/app/src/main/java/githubuser/adapter/GitHubAdaptor.java
+++ b/app/src/main/java/githubuser/adapter/GitHubAdaptor.java
@@ -1,5 +1,4 @@
-//package adaptor;
-package githubuser.view;
+package githubuser.adapter;
 
 import android.content.Context;
 import android.content.Intent;
@@ -15,6 +14,7 @@ import com.example.jakanakiwanuka.mrmlevelup.R;
 import java.util.List;
 
 import githubuser.model.GithubUsers;
+import githubuser.view.DetailActivity;
 
 /**
  * An adaptor to cater to the generation of the RecyclerView.

--- a/app/src/main/java/githubuser/model/GithubUsers.java
+++ b/app/src/main/java/githubuser/model/GithubUsers.java
@@ -16,7 +16,7 @@ public class GithubUsers {
     @SerializedName("avatar_url")
     private final String profileImage; //tochange
 
-    @SerializedName("organization_url")
+    @SerializedName("organizations_url")
     private final String organizationUrl; //tochange
 
     /**

--- a/app/src/main/java/githubuser/model/GithubUsersResponse.java
+++ b/app/src/main/java/githubuser/model/GithubUsersResponse.java
@@ -9,8 +9,8 @@ import java.util.List;
  * @author Jakana Kiwanuka
  */
 public class GithubUsersResponse {
-    @SerializedName("Users")
-    private List<GithubUsers> users;
+    @SerializedName("items")
+    public List<GithubUsers> users;
 
     /**
      * Public array list to return a user list.

--- a/app/src/main/java/githubuser/presenter/GithubUsersPresenter.java
+++ b/app/src/main/java/githubuser/presenter/GithubUsersPresenter.java
@@ -1,5 +1,6 @@
 package githubuser.presenter;
 
+
 import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
@@ -9,7 +10,7 @@ import java.util.List;
 import githubuser.model.GithubUsers;
 import githubuser.model.GithubUsersResponse;
 import githubuser.service.GithubService;
-import githubuser.view.GitHubAdaptor;
+import githubuser.adapter.GitHubAdaptor;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;

--- a/app/src/main/java/githubuser/presenter/GithubUsersPresenter.java
+++ b/app/src/main/java/githubuser/presenter/GithubUsersPresenter.java
@@ -4,7 +4,6 @@ package githubuser.presenter;
 import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
-
 import java.util.List;
 
 import githubuser.model.GithubUsers;
@@ -18,10 +17,9 @@ import retrofit2.Response;
  * A Presneter acts upon model data and cormats data for the view.
  * @author Jakana Kiwanuka
  */
-@SuppressWarnings("PMD")
 public class GithubUsersPresenter {
     private GithubService gitService;
-    private final Context context; //change later
+    public final Context context; //change later
 
     /**
      * Public declaration of the presenter.
@@ -36,9 +34,10 @@ public class GithubUsersPresenter {
 
     }
 
+
     /**
      * Method to get github Users.
-     * @param recyclerView the recycler view for get github users
+     *  @param recyclerView create the view to display the data
      */
     public void getGithubUsers(final RecyclerView recyclerView) {
         gitService
@@ -48,17 +47,15 @@ public class GithubUsersPresenter {
                     @Override
                     public void onResponse(Call<GithubUsersResponse> call,
                                            Response<GithubUsersResponse> response) {
-                        GithubUsersResponse data = response.body();
-                        if (data != null && data.getGithubUsers() != null) {
-                           List<GithubUsers> githubUsersList = data.getGithubUsers();
-                           RecyclerView.Adapter adapter = new GitHubAdaptor(githubUsersList,
-                                   context);
-                           recyclerView.setAdapter(adapter);
-                           recyclerView.smoothScrollToPosition(0);
-
-                        }
-
+                       List<GithubUsers> githubUsersList = response.body().getGithubUsers();
+                           if (githubUsersList != null) {
+                               RecyclerView.Adapter adapter = new GitHubAdaptor(githubUsersList,
+                                       context);
+                               recyclerView.setAdapter(adapter);
+                               recyclerView.setScrollingTouchSlop(0);
+                           }
                     }
+
 
                     @Override
                     public void onFailure(Call<GithubUsersResponse> call, Throwable t) {

--- a/app/src/main/java/githubuser/service/GitHubAPI.java
+++ b/app/src/main/java/githubuser/service/GitHubAPI.java
@@ -13,6 +13,6 @@ public interface GitHubAPI {
      * Interface implementation.
      * @return getGithubUsers the method to get all github users
      */
-    @GET("search/users?q=location:nairobi+language:java")
+    @GET("/search/users?q=location:nairobi+language:java&per_page=10&sort=followers")
     Call<GithubUsersResponse> getGithubUsers();
 }

--- a/app/src/main/java/githubuser/service/GithubService.java
+++ b/app/src/main/java/githubuser/service/GithubService.java
@@ -17,7 +17,7 @@ public class GithubService {
      * @return The API interface
      */
     public GitHubAPI getApi() {
-        String baseUrl = "http://api.github.com/";
+        String baseUrl = "https://api.github.com";
 
         if (retrofit == null) {
             retrofit = new Retrofit

--- a/app/src/main/java/githubuser/view/DetailActivity.java
+++ b/app/src/main/java/githubuser/view/DetailActivity.java
@@ -3,8 +3,10 @@ package githubuser.view;
 import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.bumptech.glide.Glide;
 import com.example.jakanakiwanuka.mrmlevelup.R;
 /**
  * This class represents the Activity responsible for passing data from one recycler view to the
@@ -13,19 +15,31 @@ import com.example.jakanakiwanuka.mrmlevelup.R;
  * @author Jakana Kiwanuka (Github: @jeancsanchez)
  */
 public class DetailActivity extends AppCompatActivity {
+    ImageView imageView;
+    TextView username;
+    TextView github;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_detail_acticity);
 
-        // Get the intent that started this activity
+        //INITIALIZE VIEWS
+        imageView = findViewById(R.id.imageView);
+        username = findViewById(R.id.userName);
+        github = findViewById(R.id.organisation);
+
+        // GET DATA
         Intent intent = getIntent();
-        String message = intent.getExtras().getString("githubUser");
-        String message2 = intent.getExtras().getString("userOrg");
-        TextView textView = findViewById(R.id.userName);
-        TextView textView1 = findViewById(R.id.Organisation);
-        textView.setText(message);
-        textView1.setText(message2);
+        String image = intent.getExtras().getString("githubImage");
+        String name = intent.getExtras().getString("githubUser");
+        String org = intent.getExtras().getString("userOrg");
+
+        //BIND DATA
+        Glide.with(this)
+                .load(image)
+                .into(imageView);
+        username.setText(name);
+        github.setText(org);
     }
 }

--- a/app/src/main/java/githubuser/view/MainActivity.java
+++ b/app/src/main/java/githubuser/view/MainActivity.java
@@ -4,14 +4,13 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.LinearLayoutManager;
-
 import com.example.jakanakiwanuka.mrmlevelup.R;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import githubuser.adapter.GitHubAdaptor;
 import githubuser.model.GithubUsers;
+import githubuser.presenter.GithubUsersPresenter;
 
 /**
  * Class that deals with the default data/activity shown when the app loads.
@@ -19,24 +18,12 @@ import githubuser.model.GithubUsers;
  */
 public class MainActivity extends AppCompatActivity {
 
-    private RecyclerView mRecyclerView;
-    private RecyclerView.Adapter mAdapter;
-    private RecyclerView.LayoutManager mLayoutManager;
-    private static List users = new ArrayList();
+    RecyclerView mRecyclerView;
+    RecyclerView.Adapter mAdapter;
+    RecyclerView.LayoutManager mLayoutManager;
+    private static List<GithubUsers> users = new ArrayList();
+    private final GithubUsersPresenter presenter = new GithubUsersPresenter(MainActivity.this);
 
-    static {
-        users.add(new GithubUsers("James", "James", "James Org"));
-        users.add(new GithubUsers("baln", "Freaky ", "Murder Inc"));
-        users.add(new GithubUsers("Jason", "nyahaha", "Murder Inc"));
-        users.add(new GithubUsers("Mr Tickles", "Mr tickles", "Isle Of Perpetual Tickling"));
-        users.add(new GithubUsers("Bust a shot", "HARAM", "Haram"));
-        users.add(new GithubUsers("Insanity", "joker", "Aren't we all"));
-        users.add(new GithubUsers("ISSSS", "Was?", "wasn't it"));
-        users.add(new GithubUsers("your", "my", "Ours"));
-        users.add(new GithubUsers("friend", "Henemy", "yass"));
-        users.add(new GithubUsers("Nyaahhhhclea", "I don know", "Neither do i"));
-
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,9 +34,10 @@ public class MainActivity extends AppCompatActivity {
         mRecyclerView.setHasFixedSize(true);
         mLayoutManager = new LinearLayoutManager(this);
         mRecyclerView.setLayoutManager(mLayoutManager);
+        presenter.getGithubUsers(mRecyclerView);
+
         mAdapter = new GitHubAdaptor(users, this);
         mRecyclerView.setAdapter(mAdapter);
     }
-
 
 }

--- a/app/src/main/java/githubuser/view/MainActivity.java
+++ b/app/src/main/java/githubuser/view/MainActivity.java
@@ -10,6 +10,7 @@ import com.example.jakanakiwanuka.mrmlevelup.R;
 import java.util.ArrayList;
 import java.util.List;
 
+import githubuser.adapter.GitHubAdaptor;
 import githubuser.model.GithubUsers;
 
 /**

--- a/app/src/main/res/layout/activity_detail_acticity.xml
+++ b/app/src/main/res/layout/activity_detail_acticity.xml
@@ -30,13 +30,13 @@
         app:layout_constraintTop_toBottomOf="@+id/imageView" />
 
     <TextView
-        android:id="@+id/Organisation"
-        android:layout_width="121dp"
-        android:layout_height="37dp"
+        android:id="@+id/organisation"
+        android:layout_width="385dp"
+        android:layout_height="46dp"
         android:layout_marginTop="30dp"
         android:text="TextView"
         android:textAlignment="center"
-        android:textSize="24sp"
+        android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/userName" />

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -5,30 +5,31 @@
     android:layout_height="100dp">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="360dp"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
-        android:layout_marginStart="20dp"
         android:layout_marginEnd="10dp"
-        android:layout_marginTop="20dp">
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="10dp">
 
         <ImageView
             android:id="@+id/user_image"
             android:layout_width="120dp"
-            android:layout_height="match_parent"
+            android:layout_height="85dp"
             android:src="@mipmap/ic_launcher" />
 
 
         <TextView
             android:id="@+id/user_name"
-            android:layout_marginTop="15dp"
-            android:layout_marginEnd="20dp"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginTop="15dp"
             android:layout_weight="1"
             android:ems="10"
             android:inputType="textPersonName"
-            android:text="github Username" />
+            android:text="github Username"
+            android:textSize="30sp" />
 
     </LinearLayout>
 


### PR DESCRIPTION
#### What does this PR do?

1. Make changes to existing github adaptor.
2. Enable display of GitHub users.
3. Enable onclick to view User details.

#### Description of Task to be completed?

1. Modify existing GitHub adaptor to transition from static data to api results.
2. Pass Data from main activity to Detail activity.

#### How should this be manually tested?
Clone the repo and run it in Android Studio
#### What are the relevant pivotal tracker stories?
#155965831

#### Screenshots (if appropriate)
**API results on first page**
![screen shot 2018-05-24 at 20 02 59](https://user-images.githubusercontent.com/30991429/40500463-7f77c2f6-5f8d-11e8-91b7-6c20fbd5c071.png)

**Individual Users details**
![screen shot 2018-05-24 at 20 03 38](https://user-images.githubusercontent.com/30991429/40500491-92f30598-5f8d-11e8-9d42-bbceb3c657fd.png)

#### Questions: